### PR TITLE
Eliminate unnecessary use of computation source.

### DIFF
--- a/nionswift_plugin/nion_experimental_4dtools/DarkCorrection4D.py
+++ b/nionswift_plugin/nion_experimental_4dtools/DarkCorrection4D.py
@@ -213,11 +213,9 @@ class DarkCorrection4DMenuItem:
                 self.__show_tool_tips('wrong_shape')
                 return
             total_bin_data_item = self.__api.library.create_data_item(title='Total bin 4D of ' + data_item.title)
-            computation = self.__api.library.create_computation('nion.total_bin_4d_SI',
-                                                                inputs={'src': api_data_item},
-                                                                outputs={'target': total_bin_data_item})
-            computation._computation.source = total_bin_data_item._data_item
-            #computation._computation.mark_update()
+            self.__api.library.create_computation('nion.total_bin_4d_SI',
+                                                  inputs={'src': api_data_item},
+                                                  outputs={'target': total_bin_data_item})
 
             total_bin_display_item = document_controller.document_model.get_display_item_for_data_item(
                                                                                                   total_bin_data_item._data_item)
@@ -233,16 +231,15 @@ class DarkCorrection4DMenuItem:
             self.__api.library._document_model.append_data_item(dark_corrected_data_item._data_item)
             dark_corrected_data_item._data_item.session_id = self.__api.library._document_model.session_id
             dark_corrected_data_item.title = '4D dark correction of ' + data_item.title
-            computation = self.__api.library.create_computation('nion.dark_correction_4d',
-                                                                inputs={'src1': api_data_item,
-                                                                        'src2': total_bin_data_item,
-                                                                        'dark_area_region': dark_subtract_area_graphic,
-                                                                        'crop_region': crop_region,
-                                                                        'bin_spectrum': True,
-                                                                        'gain_image': [],
-                                                                        'gain_mode': 'custom'},
-                                                                outputs={'target': dark_corrected_data_item})
-            computation._computation.source = dark_corrected_data_item._data_item
+            self.__api.library.create_computation('nion.dark_correction_4d',
+                                                  inputs={'src1': api_data_item,
+                                                          'src2': total_bin_data_item,
+                                                          'dark_area_region': dark_subtract_area_graphic,
+                                                          'crop_region': crop_region,
+                                                          'bin_spectrum': True,
+                                                          'gain_image': [],
+                                                          'gain_mode': 'custom'},
+                                                  outputs={'target': dark_corrected_data_item})
             dark_corrected_display_item = document_controller.document_model.get_display_item_for_data_item(
                                                                                              dark_corrected_data_item._data_item)
             document_controller.show_display_item(dark_corrected_display_item)

--- a/nionswift_plugin/nion_experimental_4dtools/FramewiseDarkCorrection.py
+++ b/nionswift_plugin/nion_experimental_4dtools/FramewiseDarkCorrection.py
@@ -243,10 +243,9 @@ class FramewiseDarkMenuItem:
                 self.__show_tool_tips('wrong_shape')
                 return
             average_data_item = self.__api.library.create_data_item(title='Frame average of ' + data_item.title)
-            computation = self.__api.library.create_computation('nion.calculate_4d_average',
-                                                                inputs={'src': api_data_item},
-                                                                outputs={'target': average_data_item})
-            computation._computation.source = average_data_item._data_item
+            self.__api.library.create_computation('nion.calculate_4d_average',
+                                                  inputs={'src': api_data_item},
+                                                  outputs={'target': average_data_item})
             average_display_item = document_controller.document_model.get_display_item_for_data_item(average_data_item._data_item)
             document_controller.show_display_item(average_display_item)
             spectrum_graphic = average_data_item.add_rectangle_region(0.5, 0.5, 0.1, 1.0)
@@ -263,19 +262,18 @@ class FramewiseDarkMenuItem:
             self.__api.library._document_model.append_data_item(dark_corrected_data_item._data_item)
             dark_corrected_data_item._data_item.session_id = self.__api.library._document_model.session_id
             dark_corrected_data_item.title = 'Framewise dark correction of ' + data_item.title
-            computation = self.__api.library.create_computation('nion.framewise_dark_correction',
-                                                                inputs={'src1': api_data_item,
-                                                                        'src2': average_data_item,
-                                                                        'spectrum_region': spectrum_graphic,
-                                                                        'top_dark_region': top_dark_graphic,
-                                                                        'bottom_dark_region': bottom_dark_graphic,
-                                                                        'bin_spectrum': True,
-                                                                        'gain_image': [],
-                                                                        'gain_mode': 'custom'},
-                                                                outputs={'target': dark_corrected_data_item})
-            computation._computation.source = dark_corrected_data_item._data_item
+            self.__api.library.create_computation('nion.framewise_dark_correction',
+                                                  inputs={'src1': api_data_item,
+                                                          'src2': average_data_item,
+                                                          'spectrum_region': spectrum_graphic,
+                                                          'top_dark_region': top_dark_graphic,
+                                                          'bottom_dark_region': bottom_dark_graphic,
+                                                          'bin_spectrum': True,
+                                                          'gain_image': [],
+                                                          'gain_mode': 'custom'},
+                                                  outputs={'target': dark_corrected_data_item})
             dark_corrected_display_item = document_controller.document_model.get_display_item_for_data_item(
-                                                                                              dark_corrected_data_item._data_item)
+                dark_corrected_data_item._data_item)
             document_controller.show_display_item(dark_corrected_display_item)
             self.__computation_data_items.update({data_item: 'source',
                                                   average_data_item._data_item: 'average',

--- a/nionswift_plugin/nion_experimental_tools/AlignMultiSI.py
+++ b/nionswift_plugin/nion_experimental_tools/AlignMultiSI.py
@@ -159,11 +159,10 @@ def align_multi_si(api: API_1_0.API, window: API_1_0.DocumentWindow):
               "align_index": align_index}
     if align_region:
         inputs["align_region"] = api._new_api_object(align_region)
-    computation = api.library.create_computation("eels.align_multi_si",
-                                                 inputs=inputs,
-                                                 outputs={"aligned_haadf": aligned_haadf,
-                                                          "aligned_si": aligned_si})
-    computation._computation.source = aligned_si._data_item
+    api.library.create_computation("eels.align_multi_si",
+                                   inputs=inputs,
+                                   outputs={"aligned_haadf": aligned_haadf,
+                                            "aligned_si": aligned_si})
     window.display_data_item(aligned_haadf)
     window.display_data_item(aligned_si)
 

--- a/nionswift_plugin/nion_experimental_tools/AlignSequenceOfMultiDimensionalData.py
+++ b/nionswift_plugin/nion_experimental_tools/AlignSequenceOfMultiDimensionalData.py
@@ -154,10 +154,9 @@ def align_multi_si(api: API_1_0.API, window: API_1_0.DocumentWindow):
               "align_region": align_region,
               "align_collection_index": align_collection_index}
 
-    computation = api.library.create_computation("nion.align_multi_d_sequence",
-                                                 inputs=inputs,
-                                                 outputs=outputs)
-    computation._computation.source = aligned_si._data_item
+    api.library.create_computation("nion.align_multi_d_sequence",
+                                   inputs=inputs,
+                                   outputs=outputs)
     window.display_data_item(aligned_si)
     if aligned_haadf is not None:
         window.display_data_item(aligned_haadf)

--- a/nionswift_plugin/nion_experimental_tools/DoubleGaussian.py
+++ b/nionswift_plugin/nion_experimental_tools/DoubleGaussian.py
@@ -96,13 +96,12 @@ class DoubleGaussianMenuItem:
         graphic.radius_2 = 0.25
         api_fft_data_item.display._display_item.add_graphic(graphic)
         api_graphic = self.__api._new_api_object(graphic)
-        computation = self.__api.library.create_computation("nion.extension.doublegaussian",
-                                                            inputs={"src": input_data_item,
-                                                                    "weight2": 0.3,
-                                                                    "ring_graphic": api_graphic},
-                                                            outputs={"target": result_data_item,
-                                                                     "filtered_fft": api_fft_data_item})
-        computation._computation.source = result_data_item._data_item
+        self.__api.library.create_computation("nion.extension.doublegaussian",
+                                              inputs={"src": input_data_item,
+                                                      "weight2": 0.3,
+                                                      "ring_graphic": api_graphic},
+                                              outputs={"target": result_data_item,
+                                                       "filtered_fft": api_fft_data_item})
         window.display_data_item(result_data_item)
         window.display_data_item(api_fft_data_item)
 

--- a/nionswift_plugin/nion_experimental_tools/MultiDimensionalProcessing.py
+++ b/nionswift_plugin/nion_experimental_tools/MultiDimensionalProcessing.py
@@ -560,10 +560,9 @@ class MeasureShiftsMenuItemDelegate:
         if bounds_graphic:
             inputs["bounds_graphic"] = bounds_graphic
 
-        computation = self.__api.library.create_computation("nion.measure_shifts",
-                                                            inputs=inputs,
-                                                            outputs={"shifts": result_data_item})
-        computation._computation.source = result_data_item._data_item
+        self.__api.library.create_computation("nion.measure_shifts",
+                                              inputs=inputs,
+                                              outputs={"shifts": result_data_item})
         window.display_data_item(result_data_item)
 
 
@@ -696,10 +695,9 @@ class ApplyShiftsMenuItemDelegate:
                   "shift_axis": self.__api._new_api_object(shift_axis_structure)
                   }
 
-        computation = self.__api.library.create_computation("nion.apply_shifts",
-                                                            inputs=inputs,
-                                                            outputs={"shifted": result_data_item})
-        computation._computation.source = result_data_item._data_item
+        self.__api.library.create_computation("nion.apply_shifts",
+                                              inputs=inputs,
+                                              outputs={"shifted": result_data_item})
         window.display_data_item(result_data_item)
 
 
@@ -756,10 +754,9 @@ class IntegrateAlongAxisMenuItemDelegate:
         if integrate_graphic:
             inputs["integration_graphic"] = integrate_graphic
 
-        computation = self.__api.library.create_computation("nion.integrate_along_axis",
-                                                            inputs=inputs,
-                                                            outputs={"integrated": result_data_item})
-        computation._computation.source = result_data_item._data_item
+        self.__api.library.create_computation("nion.integrate_along_axis",
+                                              inputs=inputs,
+                                              outputs={"integrated": result_data_item})
         window.display_data_item(result_data_item)
 
 
@@ -903,10 +900,9 @@ class CropMenuItemDelegate:
             inputs["crop_bounds_top"] = 0
             inputs["crop_bounds_bottom"] = -1
 
-        computation = self.__api.library.create_computation("nion.crop_multi_dimensional",
-                                                            inputs=inputs,
-                                                            outputs={"cropped": result_data_item})
-        computation._computation.source = result_data_item._data_item
+        self.__api.library.create_computation("nion.crop_multi_dimensional",
+                                              inputs=inputs,
+                                              outputs={"cropped": result_data_item})
         window.display_data_item(result_data_item)
 
 
@@ -963,11 +959,10 @@ class MakeTableauMenuItemDelegate:
         # Make a result data item with 3 dimensions to ensure we get a large_format data item
         result_data_item = self.__api.library.create_data_item_from_data(numpy.zeros((1,1,1)), title="Tableau of {}".format(selected_data_item.title))
 
-        computation = self.__api.library.create_computation("nion.make_tableau_image",
-                                                            inputs=inputs,
-                                                            outputs={"tableau": result_data_item})
+        self.__api.library.create_computation("nion.make_tableau_image",
+                                              inputs=inputs,
+                                              outputs={"tableau": result_data_item})
 
-        computation._computation.source = result_data_item._data_item
         window.display_data_item(result_data_item)
 
 

--- a/nionswift_plugin/nion_experimental_tools/SequenceSplitJoin.py
+++ b/nionswift_plugin/nion_experimental_tools/SequenceSplitJoin.py
@@ -88,10 +88,9 @@ class SequenceJoinMenuItem:
         api_data_items = [Facade.DataItem(data_item) for data_item in data_items]
 
         result_data_item = self.__api.library.create_data_item_from_data(numpy.zeros((1, 1, 1)), title="Joined " + data_items[0].title)
-        computation = self.__api.library.create_computation("nion.join_sequence",
-                                                            inputs={"src_list": api_data_items},
-                                                            outputs={"target": result_data_item})
-        computation._computation.source = result_data_item._data_item
+        self.__api.library.create_computation("nion.join_sequence",
+                                              inputs={"src_list": api_data_items},
+                                              outputs={"target": result_data_item})
         result_display_item = document_controller.document_model.get_display_item_for_data_item(result_data_item._data_item)
         document_controller.show_display_item(result_display_item)
 
@@ -138,10 +137,9 @@ class SequenceSplitMenuItem:
                 logging.error("Splitting sequences of more than 100 items is disabled for performance reasons.")
                 return
             result_data_items = {f"target_{i}": self.__api.library.create_data_item(title=f"Split ({i}) of " + data_item.title) for i in range(api_data_item.xdata.data_shape[0])}
-            computation = self.__api.library.create_computation("nion.split_sequence",
-                                                                inputs={"src": api_data_item},
-                                                                outputs=result_data_items)
-            computation._computation.source = result_data_items["target_0"]._data_item
+            self.__api.library.create_computation("nion.split_sequence",
+                                                  inputs={"src": api_data_item},
+                                                  outputs=result_data_items)
 
             for result_data_item in result_data_items.values():
                 result_display_item = document_controller.document_model.get_display_item_for_data_item(result_data_item._data_item)


### PR DESCRIPTION
This is part of https://github.com/nion-software/nionswift/issues/778

Computations get deleted automatically when results get deleted - so it is unnecessary to set the source of a computation to one of the results for deletion purposes. I suspect you copied the code from eels-analysis where the computation source is used as a marker for recognizing the relationship, but not as the mechanism to delete the computation. I'm also trying to eliminate that usage and providing a better recognition technique.

General note if anyone else is observing these changes: data structures (DataStructure.py) are highly experimental and we expect that they will change rapidly in the future in incompatible ways. We do not recommend using them in any situation outside of internal development.