### PR TITLE
Ensure flag to show output text gets propogated correctly on step change

### DIFF
--- a/nion/experimental/Wizard.py
+++ b/nion/experimental/Wizard.py
@@ -179,6 +179,7 @@ class AsyncWizardUIHandler(Declarative.Handler):
             self.property_changed_event.fire('current_step_index')
             self.property_changed_event.fire('current_step_title')
             self.property_changed_event.fire('current_step_description')
+            self.property_changed_event.fire('output_field_visible')
 
     @property
     def current_step(self) -> AsyncWizardStep:


### PR DESCRIPTION
The `show_output_field` flag is a per step flag, but the `property_changed_event` for the wizard was not firing on the current step changing meaning that all steps were using the flag from the first step. This change fixes that allowing each step to define the flag independently.