### PR TITLE
Create empty data items for computations to allow automatic file format choice.

### DIFF
--- a/nionswift_plugin/nion_experimental_tools/AlignMultiSI.py
+++ b/nionswift_plugin/nion_experimental_tools/AlignMultiSI.py
@@ -214,8 +214,8 @@ def menu_item_align_multi_si(api: API, window: API.DocumentWindow) -> None:
     align_multi_si(api, window, haadf_sequence_data_item, align_region, si_sequence_data_item, align_index)
 
 def align_multi_si(api: API, window: API.DocumentWindow, haadf_sequence_data_item: Facade.DataItem, bounds_graphic: Facade.Graphic | None, si_sequence_data_item: Facade.DataItem, align_index: int) -> tuple[Facade.DataItem, Facade.DataItem]:
-    aligned_haadf = api.library.create_data_item_from_data(numpy.zeros((1,1,1)))
-    aligned_si = api.library.create_data_item_from_data(numpy.zeros((1,1,1)))
+    aligned_haadf = api.library.create_data_item()
+    aligned_si = api.library.create_data_item()
 
     inputs = {"si_sequence_data_item": si_sequence_data_item,
               "haadf_sequence_data_item": haadf_sequence_data_item,
@@ -236,8 +236,7 @@ def align_multi_si(api: API, window: API.DocumentWindow, haadf_sequence_data_ite
 
 def align_multi_si2(api: API, window: API.DocumentWindow, haadf_sequence_data_item: Facade.DataItem, bounds_graphic: Facade.Graphic | None, si_sequence_data_item: Facade.DataItem) -> tuple[Facade.DataItem, Facade.DataItem, Facade.DataItem]:
     aligned_haadf = api.library.create_data_item()
-    # Make a result data item with 3 dimensions to ensure we get a large_format data item
-    aligned_si = api.library.create_data_item_from_data(numpy.zeros((1,1,1)))
+    aligned_si = api.library.create_data_item()
     shifts = api.library.create_data_item_from_data(numpy.zeros((2, 2)))
 
     haadf_xdata = haadf_sequence_data_item.xdata

--- a/nionswift_plugin/nion_experimental_tools/AlignSequenceOfMultiDimensionalData.py
+++ b/nionswift_plugin/nion_experimental_tools/AlignSequenceOfMultiDimensionalData.py
@@ -131,8 +131,8 @@ def align_multi_si(api: API_1_0.API, window: API_1_0.DocumentWindow, data_item1:
         else:
             raise ValueError(error_msg)
 
-        aligned_haadf = api.library.create_data_item_from_data(numpy.zeros((1,1,1)))
-        aligned_si = api.library.create_data_item_from_data(numpy.zeros((1,1,1)))
+        aligned_haadf = api.library.create_data_item()
+        aligned_si = api.library.create_data_item()
         outputs = {"aligned_haadf": aligned_haadf,
                    "aligned_si": aligned_si}
     else:
@@ -141,7 +141,7 @@ def align_multi_si(api: API_1_0.API, window: API_1_0.DocumentWindow, data_item1:
         si_sequence_data_item = haadf_sequence_data_item
         align_collection_index = haadf_sequence_data_item.display._display.display_data_channel.collection_index[0]
         aligned_haadf = None
-        aligned_si = api.library.create_data_item_from_data(numpy.zeros((1,1,1)))
+        aligned_si = api.library.create_data_item()
         outputs = {"aligned_si": aligned_si}
 
     align_region = None

--- a/nionswift_plugin/nion_experimental_tools/MultiDimensionalProcessing.py
+++ b/nionswift_plugin/nion_experimental_tools/MultiDimensionalProcessing.py
@@ -261,8 +261,7 @@ class MeasureShifts(MultiDimensionalProcessingComputation):
 
 
 def measure_shifts(api: Facade.API_1, window: Facade.DocumentWindow, data_item: Facade.DataItem, bounds_graphic: Facade.Graphic | None, shift_axis: str) -> Facade.DataItem:
-    # Make a result data item with 3 dimensions to ensure we get a large_format data item
-    result_data_item = api.library.create_data_item_from_data(numpy.zeros((1,1,1)))
+    result_data_item = api.library.create_data_item()
 
     settings_dict = computation_settings.get("nion.measure_shifts", dict())
     inputs = {"input_data_item": {"object": data_item, "type": "data_source"},
@@ -531,8 +530,7 @@ class IntegrateAlongAxisMenuItemDelegate:
 
         integration_axes = IntegrateAlongAxis.guess_starting_axis(selected_data_item.xdata, graphic=integrate_graphic)
 
-        # Make a result data item with 3 dimensions to ensure we get a large_format data item
-        result_data_item = self.__api.library.create_data_item_from_data(numpy.zeros((1,1,1)))
+        result_data_item = self.__api.library.create_data_item()
 
         inputs: typing.MutableMapping[str, typing.Any]
         inputs = {"input_data_item": {"object": selected_data_item, "type": "data_source"},
@@ -596,8 +594,7 @@ class Crop(MultiDimensionalProcessingComputation):
 
 
 def crop_multi_dimensional(api: Facade.API_1, window: Facade.DocumentWindow, data_item: Facade.DataItem, crop_graphic: Facade.Graphic | None, crop_axes: str) -> Facade.DataItem:
-    # Make a result data item with 3 dimensions to ensure we get a large_format data item
-    result_data_item = api.library.create_data_item_from_data(numpy.zeros((1, 1, 1)))
+    result_data_item = api.library.create_data_item()
 
     inputs: typing.MutableMapping[str, typing.Any]
     inputs = {"input_data_item": {"object": data_item, "type": "data_source"},
@@ -675,8 +672,7 @@ class MakeTableau(Symbolic.ComputationHandlerLike):
 def tableau(api: Facade.API_1, window: Facade.DocumentWindow, data_item: Facade.DataItem, scale: float) -> Facade.DataItem:
     inputs = {"input_data_item": {"object": data_item, "type": "data_source"}, "scale": scale}
 
-    # Make a result data item with 3 dimensions to ensure we get a large_format data item
-    result_data_item = api.library.create_data_item_from_data(numpy.zeros((1,1,1)))
+    result_data_item = api.library.create_data_item()
 
     api.library.create_computation("nion.make_tableau_image",
                                    inputs=inputs,
@@ -843,7 +839,7 @@ class AlignImageSequence(Symbolic.ComputationHandlerLike):
             shifted_result_data_item = self.computation.get_result("shifted_data")
             if not shifted_result_data_item:
                 api = Facade.API_1(None, ApplicationModule.app)
-                shifted_result_data_item = api.library.create_data_item_from_data(numpy.zeros((1,1,1)))
+                shifted_result_data_item = api.library.create_data_item()
                 api.application.document_windows[0].display_data_item(shifted_result_data_item)
                 self.computation.set_result("shifted_data", shifted_result_data_item)
             self.computation.set_referenced_xdata("shifted_data", shifted_xdata)
@@ -860,9 +856,8 @@ class AlignImageSequence(Symbolic.ComputationHandlerLike):
 def align_image_sequence(api: Facade.API_1, window: Facade.DocumentWindow, data_item: Facade.DataItem,
                          reference_index: int, relative_shifts: bool, max_shift: int, show_shifted_output: bool,
                          crop_to_valid: bool, bounds_graphic: Facade.Graphic | None) -> tuple[Facade.DataItem, Facade.DataItem, Facade.DataItem | None]:
-    # Make a result data item with 3 dimensions to ensure we get a large_format data item
-    result_data_item = api.library.create_data_item_from_data(numpy.zeros((1,1,1)))
-    shifts = api.library.create_data_item_from_data(numpy.zeros((2, 2)))
+    result_data_item = api.library.create_data_item()
+    shifts = api.library.create_data_item_from_data(numpy.zeros((2, 2)))  # create real data so we can update the display below
     inputs = {"input_data_item": {"object": data_item, "type": "data_source"},
               "reference_index": reference_index,
               "relative_shifts": relative_shifts,
@@ -875,7 +870,7 @@ def align_image_sequence(api: Facade.API_1, window: Facade.DocumentWindow, data_
 
     outputs = {"shifts": shifts, "integrated_sequence": result_data_item}
     if show_shifted_output:
-        shifted_result_data_item = api.library.create_data_item_from_data(numpy.zeros((1,1,1)))
+        shifted_result_data_item = api.library.create_data_item()
         outputs["shifted_data"] = shifted_result_data_item
     else:
         shifted_result_data_item = None


### PR DESCRIPTION
Please review to see if there is any reason this would not work. I tested most of the operations + the integration tests run them.

This change eliminates explicit '3 dimension data item to force hdf5 file format' data creation, which shouldn't be necessary. The data item format will be updated according to internal criteria, which happens to be ndata for < 16MB and h5 > 16MB right now.